### PR TITLE
Disable Treesitter for markdown and tex

### DIFF
--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -49,7 +49,11 @@ require('lazy').setup({
     config = function()
       require("nvim-treesitter.configs").setup {
         ensure_installed = { "c", "lua", "rust" },
-        highlight = { enable = true, }
+        highlight = {
+          enable = true,
+          -- Avoid Invalid 'end_row' errors for filetypes with unstable parsers
+          disable = { "markdown", "tex" },
+        }
       }
     end
   },


### PR DESCRIPTION
## Summary
- avoid Invalid 'end_row' highlighter errors by disabling Tree-sitter on markdown/tex files

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6adf08a88327a4cf7a532d2ce8b6